### PR TITLE
POOD round 5: rename typo'd report key, harden action discovery, immutable change-env

### DIFF
--- a/src/actions/geek-lab/change-env.js
+++ b/src/actions/geek-lab/change-env.js
@@ -7,18 +7,14 @@ export default ({ config }) => ({
     .option('env', { describe: 'environment', type: 'string' })
     .demandOption('env', 'Please provide parameter --env'),
   handler: (argv) => {
-    const configFileContent = config.read();
+    const current = config.read();
     const environment = argv.env;
 
-    if (!configFileContent[environment]) {
+    if (!current[environment]) {
       throw new Error('Environment dont exist on cli configuration');
     }
 
-    configFileContent.env = environment;
-    configFileContent.token = null;
-    configFileContent.tokenExpires = null;
-
-    config.write(configFileContent);
+    config.write({ ...current, env: environment, token: null, tokenExpires: null });
 
     console.log(`Successfully moved cli to use "${environment}"`);
   },

--- a/src/handlebars/metrics_template.hb
+++ b/src/handlebars/metrics_template.hb
@@ -76,7 +76,7 @@
 
             </div>
             <hr/>
-            {{#each generatedeEachActionlGraph}}
+            {{#each generatedEachActionGraph}}
               {{#if openNewRow}}
                 <div class = "row">
               {{/if}}

--- a/src/utils/actions/index.js
+++ b/src/utils/actions/index.js
@@ -1,9 +1,18 @@
 const ACTION_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
 
-export function listFiles({ fs, pathLib, dirs }) {
+export function listFiles({ fs, pathLib, dirs, warn = console.warn }) {
   const files = new Set();
   for (const dir of dirs) {
-    const entries = fs.readdirSync(dir, { recursive: true, withFileTypes: true });
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { recursive: true, withFileTypes: true });
+    } catch (e) {
+      if (e.code === 'ENOENT') {
+        warn(`[geek-lab] skipping customActionsPath "${dir}": directory does not exist`);
+        continue;
+      }
+      throw e;
+    }
     for (const entry of entries) {
       if (entry.isFile()) {
         files.add(pathLib.join(entry.parentPath, entry.name));
@@ -31,7 +40,7 @@ async function loadActionFromFile({ loader, file, deps, warn }) {
 }
 
 export async function discoverActions({ fs, pathLib, loader, dirs, deps, warn = console.warn }) {
-  const files = listFiles({ fs, pathLib, dirs })
+  const files = listFiles({ fs, pathLib, dirs, warn })
     .filter((file) => ACTION_EXTENSIONS.has(pathLib.extname(file)));
 
   const seen = new Map();

--- a/src/utils/config/index.js
+++ b/src/utils/config/index.js
@@ -13,7 +13,7 @@ export function readConfig(fs, configPath) {
 }
 
 export function writeConfig(fs, configPath, data) {
-  fs.writeFileSync(configPath, JSON.stringify(data, null, '  '));
+  fs.writeFileSync(configPath, JSON.stringify(data, null, 2));
 }
 
 export function resolveValue(config, key) {

--- a/src/utils/metrics/index.js
+++ b/src/utils/metrics/index.js
@@ -3,7 +3,7 @@ export function readMetrics(fs, metricsPath) {
 }
 
 export function writeMetrics(fs, metricsPath, data) {
-  fs.writeFileSync(metricsPath, JSON.stringify(data, null, '  '));
+  fs.writeFileSync(metricsPath, JSON.stringify(data, null, 2));
 }
 
 export function recordUsage({ store, clock, command }) {

--- a/src/utils/metrics/report.js
+++ b/src/utils/metrics/report.js
@@ -42,7 +42,7 @@ export function buildReportData(store, genId) {
 
   return {
     generatedOverallGraph: buildOverallGraph({ actions, days, totalUsage: store.totalUsage, perDay, genId }),
-    generatedeEachActionlGraph: buildEachActionGraph({ actions, days, perDay, genId }),
+    generatedEachActionGraph: buildEachActionGraph({ actions, days, perDay, genId }),
   };
 }
 

--- a/test/e2e/custom-actions.spec.js
+++ b/test/e2e/custom-actions.spec.js
@@ -98,6 +98,24 @@ describe('#e2e/custom-actions', () => {
     );
   });
 
+  it('warns and keeps booting when customActionsPath points at a directory that does not exist', async () => {
+    env = createCliEnv();
+    const missing = path.join(env.home, 'does-not-exist');
+    const cfg = env.readConfig();
+    cfg.customActionsPath = [missing];
+    env.writeConfig(cfg);
+
+    const { stdout, stderr, status } = await env.run(['default-actions']);
+
+    assert.strictEqual(status, 0);
+    assert.ok(stdout.includes('Default actions are located at:'));
+    const out = stdout + stderr;
+    assert.ok(
+      out.includes('skipping customActionsPath') && out.includes(missing),
+      `expected skip warning naming the missing dir, got:\n${out}`
+    );
+  });
+
   it('lists every file discovered under customActionsPath', async () => {
     env = createCliEnv();
 

--- a/test/utils/actions.spec.js
+++ b/test/utils/actions.spec.js
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import path from 'path';
+import { listFiles } from '../../src/utils/actions/index.js';
+
+function fakeFs(byDir) {
+  return {
+    readdirSync: (dir) => {
+      const entry = byDir[dir];
+      if (entry === 'ENOENT') {
+        const e = new Error(`ENOENT: no such file or directory, scandir '${dir}'`);
+        e.code = 'ENOENT';
+        throw e;
+      }
+      if (entry === 'EACCES') {
+        const e = new Error(`EACCES: permission denied, scandir '${dir}'`);
+        e.code = 'EACCES';
+        throw e;
+      }
+      return entry;
+    },
+  };
+}
+
+function file(parentPath, name) {
+  return { isFile: () => true, parentPath, name };
+}
+
+describe('#utils/actions/listFiles', () => {
+  it('skips a missing directory and emits a warning naming it', () => {
+    const warnings = [];
+    const out = listFiles({
+      fs: fakeFs({
+        '/missing': 'ENOENT',
+        '/present': [file('/present', 'a.js')],
+      }),
+      pathLib: path,
+      dirs: ['/missing', '/present'],
+      warn: (msg) => warnings.push(msg),
+    });
+
+    assert.deepStrictEqual(out, [path.join('/present', 'a.js')]);
+    assert.strictEqual(warnings.length, 1);
+    assert.ok(warnings[0].includes('/missing'));
+    assert.ok(warnings[0].includes('directory does not exist'));
+  });
+
+  it('rethrows non-ENOENT readdir failures (e.g. permission denied)', () => {
+    assert.throws(
+      () => listFiles({
+        fs: fakeFs({ '/locked': 'EACCES' }),
+        pathLib: path,
+        dirs: ['/locked'],
+        warn: () => undefined,
+      }),
+      /EACCES/
+    );
+  });
+});

--- a/test/utils/metrics-report.spec.js
+++ b/test/utils/metrics-report.spec.js
@@ -13,7 +13,7 @@ describe('#utils/metrics/report/buildReportData', () => {
     assert.strictEqual(data.generatedOverallGraph.length, 2);
     assert.deepStrictEqual(JSON.parse(data.generatedOverallGraph[0].data), []);
     assert.deepStrictEqual(JSON.parse(data.generatedOverallGraph[1].data), []);
-    assert.deepStrictEqual(data.generatedeEachActionlGraph, []);
+    assert.deepStrictEqual(data.generatedEachActionGraph, []);
   });
 
   it('builds the donut series from totalUsage', () => {
@@ -58,7 +58,7 @@ describe('#utils/metrics/report/buildReportData', () => {
       dailyUsage: {},
     }, counterId());
 
-    const flags = data.generatedeEachActionlGraph.map(({ openNewRow, closeRow }) => ({ openNewRow, closeRow }));
+    const flags = data.generatedEachActionGraph.map(({ openNewRow, closeRow }) => ({ openNewRow, closeRow }));
     assert.deepStrictEqual(flags, [
       { openNewRow: true, closeRow: false },
       { openNewRow: false, closeRow: false },
@@ -76,8 +76,8 @@ describe('#utils/metrics/report/buildReportData', () => {
 
     assert.strictEqual(data.generatedOverallGraph[0].id, 'graphic_0');
     assert.strictEqual(data.generatedOverallGraph[1].id, 'graphic_1');
-    assert.strictEqual(data.generatedeEachActionlGraph[0].id, 'graphic_each_action_2');
-    assert.strictEqual(data.generatedeEachActionlGraph[1].id, 'graphic_each_action_3');
+    assert.strictEqual(data.generatedEachActionGraph[0].id, 'graphic_each_action_2');
+    assert.strictEqual(data.generatedEachActionGraph[1].id, 'graphic_each_action_3');
   });
 });
 
@@ -94,7 +94,7 @@ describe('#utils/metrics/report/renderReport', () => {
     const handlebars = {
       compile: (src) => {
         compiled.push(src);
-        return (data) => `rendered:${data.generatedOverallGraph.length}:${data.generatedeEachActionlGraph.length}`;
+        return (data) => `rendered:${data.generatedOverallGraph.length}:${data.generatedEachActionGraph.length}`;
       },
     };
 


### PR DESCRIPTION
## Summary

- **Rename misspelled report key.** `generatedeEachActionlGraph` → `generatedEachActionGraph` across `src/utils/metrics/report.js`, `src/handlebars/metrics_template.hb`, and `test/utils/metrics-report.spec.js`. Kills a fragile cross-file contract built on a typo.
- **Harden action discovery.** `listFiles` now warns and skips ENOENT directories instead of crashing the entire CLI; non-ENOENT errors still rethrow. New e2e in `custom-actions.spec.js` + new unit spec `test/utils/actions.spec.js` lock the behavior in.
- **Immutable `change-env`.** Handler writes a fresh config object instead of mutating the result of `config.read()`, matching the immutable style already used in `recordUsage`.
- **JSON indent literal.** `JSON.stringify(..., 2)` instead of `'  '` in config + metrics writers (idiomatic; identical bytes on disk).
- **Cleanup.** Removed three stale `awesome_metrics_graph_*.html` artefacts left under `src/handlebars/` (already gitignored).

Tests: 159 → 162 passing. Coverage held at 100/100/100/100. Lint clean.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes with 100/100/100/100 coverage
- [x] New e2e `custom-actions.spec.js` covers the missing-dir warn-and-skip path
- [x] New unit `test/utils/actions.spec.js` covers ENOENT skip + non-ENOENT rethrow
- [ ] CI green on Node 22.12.x and 24.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)